### PR TITLE
Add Linux support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,36 @@ module.exports = () => {
 			childProcess.execFileSync('rundll32.exe', ['user32.dll,LockWorkStation']);
 			break;
 		}
+		case 'linux': {
+			// See: https://askubuntu.com/questions/184728/how-do-i-lock-the-screen-from-a-terminal
+			const commands = [{
+				name: 'xdg-screensaver',
+				arg: 'lock'
+			}, {
+				name: 'gnome-screensaver-command',
+				arg: '-l'
+			}, {
+				name: 'vlock',
+				arg: '-a -s'
+			}];
+
+			const existingCommand = commands.find(command => {
+				try {
+					const result = childProcess.execFileSync('which', [command.name], { encoding: 'utf8' });
+					return result && result.length;
+				} catch (err) {
+					return false;
+				}
+			});
+
+			if (existingCommand) {
+				childProcess.execFileSync(existingCommand.name, [existingCommand.arg]);
+			} else {
+				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver or vlock and try again.');
+			}
+
+			break;
+		}
 		default: {
 			throw new Error(`Unsupported OS '${process.platform}'`);
 		}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,29 @@
 'use strict';
+
 const path = require('path');
 const childProcess = require('child_process');
+
+const getExistingLinuxCommand = () => {
+	const commands = [{
+		name: 'xdg-screensaver',
+		arg: 'lock'
+	}, {
+		name: 'gnome-screensaver-command',
+		arg: '--lock'
+	}, {
+		name: 'vlock',
+		arg: '-a -s'
+	}];
+
+	return commands.find(command => {
+		try {
+			const result = childProcess.execFileSync('which', [command.name], { encoding: 'utf8' });
+			return result && result.length;
+		} catch (err) {
+			return false;
+		}
+	});
+};
 
 module.exports = () => {
 	switch (process.platform) {
@@ -16,25 +39,7 @@ module.exports = () => {
 		}
 		case 'linux': {
 			// See: https://askubuntu.com/questions/184728/how-do-i-lock-the-screen-from-a-terminal
-			const commands = [{
-				name: 'xdg-screensaver',
-				arg: 'lock'
-			}, {
-				name: 'gnome-screensaver-command',
-				arg: '-l'
-			}, {
-				name: 'vlock',
-				arg: '-a -s'
-			}];
-
-			const existingCommand = commands.find(command => {
-				try {
-					const result = childProcess.execFileSync('which', [command.name], { encoding: 'utf8' });
-					return result && result.length;
-				} catch (err) {
-					return false;
-				}
-			});
+			const existingCommand = getExistingLinuxCommand();
 
 			if (existingCommand) {
 				childProcess.execFileSync(existingCommand.name, [existingCommand.arg]);

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
-
 const path = require('path');
 const childProcess = require('child_process');
 
 const getExistingLinuxCommand = () => {
+	// See: https://askubuntu.com/questions/184728/how-do-i-lock-the-screen-from-a-terminal
 	const commands = [{
 		name: 'xdg-screensaver',
 		arg: 'lock'
@@ -17,8 +17,8 @@ const getExistingLinuxCommand = () => {
 
 	return commands.find(command => {
 		try {
-			const result = childProcess.execFileSync('which', [command.name], { encoding: 'utf8' });
-			return result && result.length;
+			const result = childProcess.execFileSync('which', [command.name], {encoding: 'utf8'});
+			return result && result.length > 0;
 		} catch (err) {
 			return false;
 		}
@@ -38,7 +38,6 @@ module.exports = () => {
 			break;
 		}
 		case 'linux': {
-			// See: https://askubuntu.com/questions/184728/how-do-i-lock-the-screen-from-a-terminal
 			const existingCommand = getExistingLinuxCommand();
 
 			if (existingCommand) {

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const getExistingLinuxCommand = () => {
 		name: 'gnome-screensaver-command',
 		arg: '--lock'
 	}, {
-		name: 'vlock',
-		arg: '-a -s'
+		name: 'dm-tool',
+		arg: 'lock'
 	}];
 
 	return commands.find(command => {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = () => {
 			if (existingCommand) {
 				childProcess.execFileSync(existingCommand.name, [existingCommand.arg]);
 			} else {
-				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver or vlock and try again.');
+				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver or dm-tool and try again.');
 			}
 
 			break;

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Shows the login screen the next time you use the computer.
 
-Supports macOS and Windows.
+Supports macOS, Windows and Linux.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Shows the login screen the next time you use the computer.
 
-Supports macOS, Windows and Linux.
+Supports macOS, Linux, and Windows.
 
 
 ## Install


### PR DESCRIPTION
Linux support is not as straightforward as it has variety of distributions and related commands.

This adds basic Linux support based on [these suggestions](https://askubuntu.com/questions/184728/how-do-i-lock-the-screen-from-a-terminal), specifically, checking for one of these 3 commands exist on the Linux machine: `xdg-screensaver`, `gnome-screensaver-command` and `vlock`. If none of these commands exist, script throws an error with suggestion to install one of the abovementioned.