### PR TITLE
Add support for cinnamon linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ const getExistingLinuxCommand = () => {
 		name: 'gnome-screensaver-command',
 		arg: '--lock'
 	}, {
+		name: 'cinnamon-screensaver-command',
+		arg: '--lock'
+	}, {
 		name: 'dm-tool',
 		arg: 'lock'
 	}];

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = () => {
 			if (existingCommand) {
 				childProcess.execFileSync(existingCommand.name, [existingCommand.arg]);
 			} else {
-				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver, or dm-tool, and try again.');
+				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver, cinnamon-screensaver-command, or dm-tool, and try again.');
 			}
 
 			break;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = () => {
 			if (existingCommand) {
 				childProcess.execFileSync(existingCommand.name, [existingCommand.arg]);
 			} else {
-				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver, cinnamon-screensaver-command, or dm-tool, and try again.');
+				throw new Error('No applicable command found. Please consider installing xdg-screensaver, gnome-screensaver, cinnamon-screensaver, or dm-tool, and try again.');
 			}
 
 			break;


### PR DESCRIPTION
Adds support for the cinnamon screensaver interface.

One thing I noticed, might be an idea for the future, `xdm-screensaver` is installed on several linux systems but not connected to the desktop, thus running `which xdm-screensaver` does return but does not actually fire the lock command. Might be an idea to move it below the `dm-tool` as a lower priority command.